### PR TITLE
Change #include "src/compiled.h" to just "compiled.h"

### DIFF
--- a/Makefile.gappkg
+++ b/Makefile.gappkg
@@ -3,8 +3,8 @@
 # The build rules in this file are intended for use by GAP packages that
 # want to build a simple GAP kernel extensions. They are based on the
 # GAP build system, and require GNU make. To use this in your GAP
-# package, `include` this from your primary Makefile. You must also set
-# several variables beforehand:
+# package, `include` this file from your primary Makefile. You must also
+# set several variables beforehand:
 #
 # - GAPPATH must be set to the location of the GAP installation against
 #   which to build your package.
@@ -13,7 +13,9 @@
 # - KEXT_SOURCES must contain a list of .c or .cc files to be linked
 #   into your kernel extension
 # - optionally, you can set KEXT_CFLAGS, KEXT_CXXFLAGS, KEXT_LDFLAGS
-#
+# - if you are using autoconf to produce your configure script, set
+#   KEXT_USE_AUTOCONF to 1 to enable dependency rules that enable
+#   regenerating the configure script etc. when necessary
 #
 # Only GAP >= 4.11 ships with this file. In order to keep your package
 # compatible with older GAP versions, we recommend to bundle a copy of
@@ -27,15 +29,22 @@
 # package, etc.
 #
 # If you bundle this file with your package, please try not to edit it,
-# so that we can keep it identical across all GAP packages. If you still
-# find that you must edit it, please consider submitting your changes
-# back to the GAP team, so that a future version of this file can be
-# adjusted to cover your usecase without modifications.
+# so that we can keep it identical across all GAP packages. Instead, if
+# you find that you must edit it, please submit your changes back to
+# the GAP team, so that a future version of this file can be adjusted
+# to cover your usecase without modifications, thus ensuring you can
+# always easily update to newer version of it.
 #
 ########################################################################
 
 # read GAP's build settings
 include $(GAPPATH)/sysinfo.gap
+
+# hack to support GAP <= 4.9
+ifndef GAP_KERNEL_MAJOR_VERSION
+  KEXT_CFLAGS += -I$(GAP_LIB_DIR)/src
+  KEXT_CXXFLAGS += -I$(GAP_LIB_DIR)/src
+endif
 
 # various derived settings
 KEXT_BINARCHDIR = bin/$(GAParch)
@@ -46,7 +55,11 @@ GAC = $(GAPPATH)/gac
 
 # override KEXT_RECONF if your package needs a different invocation
 # for reconfiguring (e.g. `./config.status --recheck` for autoconf)
+ifdef KEXT_USE_AUTOCONF
+KEXT_RECONF ?= ./config.status Makefile
+else
 KEXT_RECONF ?= ./configure "$(GAPPATH)"
+endif
 
 # default target
 all: $(KEXT_SO)
@@ -57,7 +70,10 @@ all: $(KEXT_SO)
 # For each file FOO.c in SOURCES, add gen/FOO.lo to KEXT_OBJS; similar
 # for .cc files
 ########################################################################
-KEXT_OBJS = $(patsubst %.cc,gen/%.lo,$(patsubst %.c,gen/%.lo,$(KEXT_SOURCES)))
+KEXT_OBJS = $(patsubst %.s,gen/%.lo, \
+            $(patsubst %.cc,gen/%.lo, \
+            $(patsubst %.c,gen/%.lo, \
+                $(KEXT_SOURCES))))
 
 ########################################################################
 # Quiet rules.
@@ -76,13 +92,10 @@ endif
 # This is based on the GAP build system.
 ########################################################################
 
-# List of all (potential) dependency directories, derived from KEXT_OBJS
-# and KEXT_SOURCES (the latter for generated sources, which may also
-# involve dependency tracking)
-KEXT_DEPDIRS = $(sort $(dir $(KEXT_SOURCES) $(KEXT_OBJS)))
-KEXT_DEPFILES = $(wildcard $(addsuffix /*.d,$(KEXT_DEPDIRS)))
+# List of all (potential) dependency files, derived from KEXT_OBJS
+KEXT_DEPFILES = $(patsubst %.lo,%.d,$(KEXT_OBJS))
 
-# Include the dependency tracking files.
+# Include the dependency tracking files
 -include $(KEXT_DEPFILES)
 
 # Mark *.d files as PHONY. This stops make from trying to recreate them
@@ -98,17 +111,22 @@ KEXT_DEPFLAGS = -MQ "$@" -MMD -MP -MF $(@D)/$(*F).d
 # build rule for C code
 # The dependency on Makefile ensures that re-running configure recompiles everything
 gen/%.lo: %.c Makefile
-	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CFLAGS)" -c $< -o $@
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CFLAGS)" -p "$(CFLAGS)" -c $< -o $@
 
 # build rule for C++ code
 # The dependency on Makefile ensures that re-running configure recompiles everything
 gen/%.lo: %.cc Makefile
-	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CXXFLAGS)" -c $< -o $@
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CXXFLAGS)" -p "$(CXXFLAGS)" -c $< -o $@
+
+# build rule for assembler code
+# The dependency on Makefile ensures that re-running configure recompiles everything
+gen/%.lo: %.s Makefile
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CFLAGS)" -p "$(CFLAGS)" -c $< -o $@
 
 # build rule for linking all object files together into a kernel extension
 $(KEXT_SO): $(KEXT_OBJS)
 	@mkdir -p $(KEXT_BINARCHDIR)
-	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -P "$(KEXT_LDFLAGS)" $(KEXT_OBJS) -o $@
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -P "$(KEXT_LDFLAGS)" -P "$(LDFLAGS)" $(KEXT_OBJS) -o $@
 
 # hook into `make clean`
 clean: clean-kext
@@ -134,6 +152,53 @@ check-kext:
 # re-run configure if configure, Makefile.in or GAP itself changed
 Makefile: configure Makefile.in $(GAPPATH)/sysinfo.gap
 	$(KEXT_RECONF)
+
+ifdef KEXT_USE_AUTOCONF
+
+# react to modifications of the build system
+configure_deps = configure.ac $(wildcard m4/*.m4)
+
+ifneq ($(MAINTAINER_MODE),no)
+configure: $(configure_deps)
+	@if command -v autoconf >/dev/null 2>&1 ; then \
+	   echo "running autoconf" ; \
+	   autoconf ; \
+	 else \
+	   echo "autoconf not available, proceeding with stale configure" ; \
+	 fi
+endif # MAINTAINER_MODE
+
+# re-run configure if configure, Makefile.in or GAP itself changed
+config.status: configure $(GAPPATH)/sysinfo.gap
+	./config.status --recheck
+
+# update Makefile if config.status changed
+Makefile: config.status
+
+gen/pkgconfig.h: gen/pkgconfig.h.stamp
+	@if test ! -f $@; then rm -f $<; else :; fi
+	@if test ! -f $@; then $(MAKE) $<; else :; fi
+
+gen/pkgconfig.h.stamp: gen/pkgconfig.h.in config.status
+	@rm -f $@
+	@mkdir -p $(@D)
+	./config.status gen/pkgconfig.h
+	echo > $@
+
+ifneq ($(MAINTAINER_MODE),no)
+gen/pkgconfig.h.in: $(configure_deps)
+	@if command -v autoheader >/dev/null 2>&1 ; then \
+	   mkdir -p $(@D) ; \
+	   echo "running autoheader" ; \
+	   autoheader ; \
+	   rm -f gen/pkgconfig.h.stamp ; \
+	 else \
+	   echo "autoheader not available, proceeding with stale config.h" ; \
+	 fi
+	touch $@
+endif # MAINTAINER_MODE
+
+endif # KEXT_USE_AUTOCONF
 
 .PHONY: check clean distclean doc
 .PHONY: check-kext clean-kext distclean-kext doc-kext

--- a/Makefile.in
+++ b/Makefile.in
@@ -20,7 +20,7 @@ KEXT_CXXFLAGS = $(timingflag) $(checkflag) \
     -IYAPB++/source \
     -Igap_cpp_headers
 
-KEXT_RECONF ?= ./config.status Makefile
+KEXT_USE_AUTOCONF = 1
 
 # include shared GAP package build system
 GAPPATH = @GAPROOT@
@@ -39,25 +39,3 @@ symmetry_detect: .FORCE
 
 .FORCE:
 .PHONY: .FORCE
-
-
-#
-# react to modifications of the build system
-#
-
-configure_deps = configure.ac $(wildcard m4/*.m4)
-
-configure: $(configure_deps)
-	@if command -v autoconf >/dev/null 2>&1 ; then \
-	   echo "running autoconf" ; \
-	   autoconf ; \
-	 else \
-	   echo "autoconf not available, proceeding with stale configure" ; \
-	 fi
-
-# re-run configure if configure, Makefile.in or GAP itself changed
-config.status: configure $(GAPPATH)/sysinfo.gap
-	./config.status --recheck
-
-# update Makefile if config.status changed
-Makefile: config.status

--- a/gap_cpp_headers/gap_cpp_mapping.hpp
+++ b/gap_cpp_headers/gap_cpp_mapping.hpp
@@ -8,7 +8,7 @@
 #include <deque>
 #include <list>
 
-// We have to include this to get around problems with the 'extern C' wrapping of src/compiled.h,
+// We have to include this to get around problems with the 'extern C' wrapping of compiled.h,
 // which includes gmp, which in C++ mode has some C++ templates.
 #include "include_gap_headers.hpp"
 #include "gap_exception.hpp"

--- a/gap_cpp_headers/include_gap_headers.hpp
+++ b/gap_cpp_headers/include_gap_headers.hpp
@@ -5,7 +5,7 @@
 #include <stddef.h>
 #include "gmp.h"
 extern "C" {
-#include "src/compiled.h"
+#include "compiled.h"
 }
 
 #endif

--- a/m4/find_gap.m4
+++ b/m4/find_gap.m4
@@ -18,8 +18,7 @@ AC_DEFUN([FIND_GAP],
   AC_MSG_CHECKING([for GAP root directory])
   GAPROOT="../.."
 
-  #Allow the user to specify the location of GAP
-  #
+  # Allow the user to specify the location of GAP
   AC_ARG_WITH(gaproot,
     [AS_HELP_STRING([--with-gaproot=<path>], [specify root of GAP installation])],
     [GAPROOT="$withval"])
@@ -72,65 +71,20 @@ AC_DEFUN([FIND_GAP],
     AC_MSG_ERROR([Unable to find plausible GAParch information.])
   fi
 
-
-  AC_MSG_CHECKING([for GAP >= 4.9])
-  # test if this GAP >= 4.9
-  if test "x$GAP_CPPFLAGS" != x; then
-    AC_MSG_RESULT([yes])
-  else
-    AC_MSG_RESULT([no])
-    #####################################
-    # Now check for the GAP header files
-
-    bad=0
-    AC_MSG_CHECKING([for GAP include files])
-    if test -r $GAPROOT/src/compiled.h; then
-      AC_MSG_RESULT([$GAPROOT/src/compiled.h])
-    else
-      AC_MSG_RESULT([Not found])
-      bad=1
-    fi
-    AC_MSG_CHECKING([for GAP config.h])
-    if test -r $GAPROOT/bin/$GAPARCH/config.h; then
-      AC_MSG_RESULT([$GAPROOT/bin/$GAPARCH/config.h])
-    else
-      AC_MSG_RESULT([Not found])
-      bad=1
-    fi
-
-    if test "x$bad" = "x1"; then
-      echo ""
-      echo "********************************************************************"
-      echo "  ERROR"
-      echo ""
-      echo "  Failed to find the GAP source header files in src/ and"
-      echo "  GAP's config.h in the architecture dependend directory"
-      echo ""
-      echo "  The kernel build process expects to find the normal GAP "
-      echo "  root directory structure as it is after building GAP itself, and"
-      echo "  in particular the files"
-      echo "      <gaproot>/sysinfo.gap"
-      echo "      <gaproot>/src/<includes>"
-      echo "  and <gaproot>/bin/<architecture>/bin/config.h."
-      echo "  Please make sure that your GAP root directory structure"
-      echo "  conforms to this layout, or give the correct GAP root using"
-      echo "  --with-gaproot=<path>"
-      echo "********************************************************************"
-      echo ""
-      AC_MSG_ERROR([Unable to find GAP include files in /src subdirectory])
-    fi
-
-    ARCHPATH=$GAPROOT/bin/$GAPARCH
-    GAP_CPPFLAGS="-I$GAPROOT -iquote $GAPROOT/src -I$ARCHPATH"
-
-    AC_MSG_CHECKING([for GAP's gmp.h location])
-    if test -r "$ARCHPATH/extern/gmp/include/gmp.h"; then
-      GAP_CPPFLAGS="$GAP_CPPFLAGS -I$ARCHPATH/extern/gmp/include"
-      AC_MSG_RESULT([$ARCHPATH/extern/gmp/include/gmp.h])
-    else
-      AC_MSG_RESULT([not found, GAP was compiled without its own GMP])
-    fi
+  # require GAP >= 4.9
+  if test "x$GAP_CPPFLAGS" = x; then
+    echo ""
+    echo "********************************************************************"
+    echo "  ERROR"
+    echo ""
+    echo "  This version of GAP is too old and not supported by this package."
+    echo "********************************************************************"
+    echo ""
+    AC_MSG_ERROR([No GAP_CPPFLAGS is given])
   fi
+
+  # compatibility with GAP 4.9 (not needed in GAP >= 4.10)
+  GAP_CPPFLAGS="$GAP_CPPFLAGS -I${GAP_LIB_DIR}/src"
 
   AC_SUBST(GAPARCH)
   AC_SUBST(GAPROOT)


### PR DESCRIPTION
This will allow future GAP versions to simplify their GAP_CPPFLAGS,
which currently need to contain `-I$(abs_srcdir)` just to support this
old use case. Also, this in turn makes it easier to have package
compatible with future installed version of GAP, which have headers in
PREFIX/include/gap/ so there is no `src` there (unless downstream
packagers jump through hoops to ensure that, e.g. by adding a special
symlink).

Note: we could also #include "gap_all.h" but that would require GAP >= 4.11.

Also includes PR #32