### PR TITLE
Don't print in AvailabilityTest

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -72,8 +72,6 @@ Dependencies := rec(
 
 AvailabilityTest := function()
   if Filename(DirectoriesPackagePrograms("ferret"), "ferret.so") = fail then
-    Print("Error: Cannot load 'Ferret' due to missing binary library\n");
-    Print("Please run './configure; make' in the 'pkg/ferret' directory\n");
     return fail;
   fi;
   return true;


### PR DESCRIPTION
This function is also called from TestPackageAvailability to test if a
package can be loaded; and thus also e.g. by PackageManager. It does so
specifically to test if the package needs to be built. The current error
message thus is highly confusing.