### PR TITLE
PackageInfo.g: add License field

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -4,6 +4,7 @@ PackageName := "ferret",
 Subtitle := "Backtrack Search in Permutation Groups",
 Version := "1.0.2dev",
 Date := "17/01/2019", # dd/mm/yyyy format
+License := "MPL-2.0",
 
 Persons := [
   rec(


### PR DESCRIPTION
.... I hope MPL 2.0 *is* the correct license? While you bundle the license file, you never explicitly state that this is the license of the code (I believe that from a legal point of view, that's necessary, but IANAL *shrug*). Anyway, having this machine readable would be helpful for e.g. packagers and also our package distribution.

BTW, once this is merged, it'd be terrific if you could make a new ferret release.