### PR TITLE
Avoid ostringstream no-argument constructor

### DIFF
--- a/YAPB++/simple_graph/symmetry_parse.cc
+++ b/YAPB++/simple_graph/symmetry_parse.cc
@@ -17,7 +17,7 @@ template<typename T>
 std::string
 tostring(const T& t)
 {
-  std::ostringstream streamOut;
+  std::ostringstream streamOut("");
   streamOut << t;
   return streamOut.str();
 }

--- a/YAPB++/source/library/debug.hpp
+++ b/YAPB++/source/library/debug.hpp
@@ -33,7 +33,7 @@
 { \
   if(level < DebugInfoLevel()) \
   { \
-    std::ostringstream oss; \
+    std::ostringstream oss(""); \
     oss << "#I " << type << ":" << message << "\n"; \
     GAP_print(oss.str()); \
   } \

--- a/YAPB++/source/library/perm.hpp
+++ b/YAPB++/source/library/perm.hpp
@@ -193,7 +193,7 @@ public:
 
     std::string cycle() const
     {
-        std::ostringstream oss;
+        std::ostringstream oss("");
         std::vector<bool> checked(size() + 1, false);
         bool some_printed = false;
         for(int i : range1(size()))

--- a/YAPB++/source/library/printing_containers.hpp
+++ b/YAPB++/source/library/printing_containers.hpp
@@ -80,7 +80,7 @@ void output_container(std::ostream& o, const T& t)
 template<typename T>
 std::string toString(const T& t)
 {
-  std::ostringstream oss;
+  std::ostringstream oss("");
   oss << t;
   return oss.str();
 }

--- a/YAPB++/source/partition_stack.hpp
+++ b/YAPB++/source/partition_stack.hpp
@@ -477,7 +477,7 @@ public:
     std::string printCurrentPartition()
     {
         vec1<vec1<int> > v = dumpCurrentPartition();
-        std::ostringstream oss;
+        std::ostringstream oss("");
         oss << "[" << markstore.marks(1) << ": ";
         for(int i : range1(n))
         {


### PR DESCRIPTION
Use `std::ostringstream oss("")` instead of `std::ostringstream oss` to work around C++ ABI difficulties.

For some background, see <https://github.com/oscar-system/Oscar.jl/issues/262> and <https://github.com/oscar-system/Polymake.jl/issues/251>