### PR TITLE
Replace u_int32_t -> uint32_t

### DIFF
--- a/YAPB++/source/library/sort_events.hpp
+++ b/YAPB++/source/library/sort_events.hpp
@@ -4,7 +4,7 @@
 #include "library/vec1.hpp"
 #include "promotable_list.hpp"
 
-typedef u_int32_t HashType;
+typedef uint32_t HashType;
 
 struct HashStart
 {


### PR DESCRIPTION
This fixes a compile error for me -- uint32_t is a standard type,
u_int32_t is not
