### PR TITLE
Prefer (CONST_)CSTR_STRING over CHARS_STRING

### DIFF
--- a/gap_cpp_headers/gap_cpp_mapping.hpp
+++ b/gap_cpp_headers/gap_cpp_mapping.hpp
@@ -48,7 +48,7 @@ struct GAP_getter<char*>
     {
         if(!isa(recval))
             throw GAPException("Invalid attempt to read string");
-        return (char*)CHARS_STRING(recval);
+        return CSTR_STRING(recval);
     }
 };
 
@@ -62,7 +62,7 @@ struct GAP_getter<std::string>
     {
         if(!isa(recval))
             throw GAPException("Invalid attempt to read string");
-        return std::string((char*)CHARS_STRING(recval));
+        return std::string(CONST_CSTR_STRING(recval));
     }
 };
 


### PR DESCRIPTION
... at least where it avoids casts
