### PR TITLE
Load atlasrep rather than atlas when testing

### DIFF
--- a/tst/test_functions.g
+++ b/tst/test_functions.g
@@ -1,5 +1,5 @@
 LoadPackage("ferret", false);
-LoadPackage("atlas", false);
+LoadPackage("atlasrep", false);
 
 ReadPackage("ferret", "tst/random_obj.g");
 


### PR DESCRIPTION
The atlas package was renamed to atlasrep some time ago.