### PR TITLE
Improve ferret.vars handing

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -37,5 +37,9 @@ symmetry_detect: .FORCE
 	    -I YAPB++/source \
 	    -o $@
 
+all: ferret.vars
+ferret.vars: ferret.vars.in config.status
+	./config.status $@
+
 .FORCE:
 .PHONY: .FORCE

--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,8 @@ dnl ##
 dnl ## Locate the GAP root dir
 dnl ##
 FIND_GAP
+GAPEXEC="${GAP:-${GAPROOT}/bin/gap.sh}" # GAP >= 4.12.0 sets "GAP"
+AC_SUBST(GAPEXEC)
 
 dnl ##
 dnl ## Set flags so libtool will use them

--- a/ferret.vars.in
+++ b/ferret.vars.in
@@ -6,4 +6,4 @@ fi
 
 export DEBUGFLAGS="-DDEBUG_LEVEL=@FERRET_CHECK@"
 export GAPPATH="@GAPROOT@"
-export GAPEXEC="${GAPPATH}/bin/gap.sh -b"
+export GAPEXEC="@GAPEXEC@ -b"


### PR DESCRIPTION
- regenerate ferret.vars whenever ferret.vars.in changes
- derive the path to GAP executable from sysinfo.gap if possible
