### PR TITLE
Enhance CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: 'ferret CI'
 
+# Trigger the workflow on push or pull request
 on:
   push:
     branches:
@@ -9,18 +10,19 @@ on:
 # the `concurrency` settings ensure that not too many CI jobs run in parallel
 concurrency:
   # group by workflow and ref; the last slightly strange component ensures that for pull
-  # requests, we limit to 1 concurrent job, but for the master branch we don't
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # requests, we limit to 1 concurrent job, but for the default repository branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref_name != github.event.repository.default_branch || github.run_number }}
   # Cancel intermediate builds, but only if it is a pull request build.
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   test:
-    name: GAP ${{ matrix.gap }} ${{ matrix.flags }}
+    name: GAP ${{ matrix.gap-branch }} ${{ matrix.flags }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        gap:
+        gap-branch:
           - 'master'
         flags:
           - ''
@@ -29,11 +31,11 @@ jobs:
           - '--enable-checking --enable-timing'
 
         include:
-          - gap: 'stable-4.14'
+          - gap-branch: 'stable-4.14'
             flags: ''
-          - gap: 'stable-4.13'
+          - gap-branch: 'stable-4.13'
             flags: ''
-          - gap: 'stable-4.12'
+          - gap-branch: 'stable-4.12'
             flags: ''
 
     steps:
@@ -52,7 +54,7 @@ jobs:
       - name: 'Build GAP and its packages'
         uses: gap-actions/setup-gap@v2
         with:
-          GAPBRANCH: ${{ matrix.gap }}
+          GAPBRANCH: ${{ matrix.gap-branch }}
 
       - name: 'Build ferret'
         uses: gap-actions/build-pkg@v1
@@ -68,3 +70,26 @@ jobs:
       - name: 'Run Valgrind tests'
         run: |
             valgrind -q --trace-children=yes --suppressions=scripts/gap-suppressions.valgrind gap -A -q -l "/tmp/gaproot;" tst/testvalgrind.g
+
+      - uses: gap-actions/process-coverage@v2
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  # The documentation job
+  manual:
+    name: Build manuals
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: gap-actions/setup-gap@v2
+      - uses: gap-actions/build-pkg-docs@v1
+        with:
+          use-latex: 'true'
+      - name: 'Upload documentation'
+        uses: actions/upload-artifact@v4
+        with:
+          name: manual
+          path: ./doc/manual.pdf
+          if-no-files-found: error


### PR DESCRIPTION
Align it a bit more with our standard setup:

- use `fail-fast: false` in the job matrix
- use `gap-branch` instead of `gap` as name for one of the matrix axes
- add code coverage
- add test for building the manual
