### PR TITLE
Release CI: temporarily manually compile json package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: gap-actions/setup-gap@v3
+      - name: "Build the json package . . ."
+        # FIXME: Remove this step when we can use gap-actions/release-pkg@v2
+        run: |
+          cd ${GAPROOT}/pkg
+          ../bin/BuildPackages.sh --strict json
       - uses: gap-actions/build-pkg-docs@v2
         with:
           use-latex: true


### PR DESCRIPTION
The `release-pkg` action makes use of the JSON package, but until version 2 of `release-pkg` (which is not yet released, so we're using version 1), the `release-pkg` action doesn't itself compile the JSON package. So we need to compile it manually for a while first.

Hopefully this will make things work again (although you might need to delete your v1.0.15 tag, or run the Release workflow with the "overwrite" option set to true).